### PR TITLE
mips_toIR: fail attempt to decode a branch or jump without its delay …

### DIFF
--- a/priv/guest_mips_toIR.c
+++ b/priv/guest_mips_toIR.c
@@ -12064,6 +12064,12 @@ static DisResult disInstr_MIPS_WRK ( Bool(*resteerOkFn) (/*opaque */void *,
    cins = getUInt(code);
    DIP("\t0x%lx:\t0x%08x\t", (long)guest_PC_curr_instr, cins);
 
+   /* Can't decode a single instruction if it is a branch or jump
+      (as the delay slot is also needed for meaningful decoding) */
+   if (vex_control.guest_max_insns == 1 && branch_or_jump(guest_code)) {
+      goto decode_failure;
+   }
+
    if (delta != 0) {
       if (branch_or_jump(guest_code + delta - 4)) {
          if (lastn == NULL && bstmt == NULL) {


### PR DESCRIPTION
…slot

This (at least partially) fixes angr/angr#71.

Note that there is already code in place
(https://github.com/angr/vex/blob/acccba9/priv/guest_mips_toIR.c#L17239) to
check if the last instruction in the to-be-decoded block is a branch or jump,
in which case the code simply stops decoding *before* that last instruction, so
as not to separate it from the delay slot. However, this check is only applied
to the "next" instruction, but not to the first instruction in the block. So if
only a single instruction is to be decoded, and it happens to be a branch or
jump, the existing code doesn't catch it.

It might be possible to modify the existing code to also catch the single-
instruction case, however that would be a more invasive change (and would
probably also require moving the whole check from the end of the function to
its beginning), so I preferred special-casing the single-instruction case.