### PR TITLE
Add MSVC implementations for ULong__maxIndex and ULong__minIndex

### DIFF
--- a/priv/host_generic_reg_alloc2.c
+++ b/priv/host_generic_reg_alloc2.c
@@ -286,11 +286,58 @@ static void sortRRLRarray ( RRegLR* arr,
    respectively.  Results are undefined if the argument is zero.
    Don't pass it zero :) */
 static inline UInt ULong__maxIndex ( ULong w64 ) {
+#ifdef _MSC_VER
+   /* This implementation should be correct with 32 or 64-bit msvc compiler.
+      Ref: https://chessprogramming.wikispaces.com/BitScan */
+   const int index64[64] = {
+        0, 47,  1, 56, 48, 27,  2, 60,
+       57, 49, 41, 37, 28, 16,  3, 61,
+       54, 58, 35, 52, 50, 42, 21, 44,
+       38, 32, 29, 23, 17, 11,  4, 62,
+       46, 55, 26, 59, 40, 36, 15, 53,
+       34, 51, 20, 43, 31, 22, 10, 45,
+       25, 39, 14, 33, 19, 30,  9, 24,
+       13, 18,  8, 12,  7,  6,  5, 63
+   };
+
+   const ULong debruijn64 = 0x03f79d71b4cb0a89;
+   ULong bb = w64;
+   bb |= bb >> 1;
+   bb |= bb >> 2;
+   bb |= bb >> 4;
+   bb |= bb >> 8;
+   bb |= bb >> 16;
+   bb |= bb >> 32;
+   return index64[(bb * debruijn64) >> 58];
+#else
    return 63 - __builtin_clzll(w64);
+#endif
 }
 
 static inline UInt ULong__minIndex ( ULong w64 ) {
+#ifdef _MSC_VER
+   /* This implementation should be correct with 32 or 64-bit msvc compiler.
+      Ref: https://chessprogramming.wikispaces.com/BitScan */
+   const int lsb_64_table[64] =
+   {
+      63, 30,  3, 32, 59, 14, 11, 33,
+      60, 24, 50,  9, 55, 19, 21, 34,
+      61, 29,  2, 53, 51, 23, 41, 18,
+      56, 28,  1, 43, 46, 27,  0, 35,
+      62, 31, 58,  4,  5, 49, 54,  6,
+      15, 52, 12, 40,  7, 42, 45, 16,
+      25, 57, 48, 13, 10, 39,  8, 44,
+      20, 47, 38, 22, 17, 37, 36, 26
+   };
+
+   unsigned int folded;
+   ULong bb = w64;
+   bb ^= bb - 1;
+   folded = (int) bb ^ (bb >> 32);
+   return lsb_64_table[folded * 0x78291ACF >> 26];
+#else
    return __builtin_ctzll(w64);
+#endif
 }
 
 


### PR DESCRIPTION
Builds are currently broken for `pyvex` on MSVC due to a couple of issues. One is here in the `vex` project (which I'll describe below) and one is in the `pyvex` project, which I've submitted another PR for (see angr/pyvex#70).

Currently, `vex` is using a couple of `gcc` builtin functions which, unsurprisngly, aren't present in the MSVC ecosystem. There are some very similar builtins in MSVC (`_BitScanForward64`, `_BitScanReverse64`) which would have done the job with some minor tweaks. However, those builtins are only present in the 64-bit compiler, which is problematic given that the default VS2015 developer prompt has the 32-bit version of `cl.exe` on its path. 

As such, I've come up with a 32-bit friendly solution by adding some implementations of the relevant algorithms from https://chessprogramming.wikispaces.com/BitScan. I haven't formally verified my implementation (and I lack the wizardry to fully understand the implementations I'm using), but from the limitied testing I've done, the results they're producing look sane (and identical to the output from the `gcc` functions).

If you'd prefer an alternate strategy for resolving this though, let me know and I'll go back to the drawing board.