### PR TITLE
Fix CB{N}Z thumb instruction second attempt

### DIFF
--- a/priv/guest_arm_toIR.c
+++ b/priv/guest_arm_toIR.c
@@ -20030,6 +20030,12 @@ DisResult disInstr_THUMB_WRK (
                         Ijk_Boring,
                         IRConst_U32(toUInt(dst)),
                         OFFB_R15T ));
+      if (vex_control.arm_strict_block_end){
+	  llPutIReg(15, mkU32( (guest_R15_curr_instr_notENC + 2) 
+			        | 1 /*CPSR.T*/ ));
+          dres.jk_StopHere = Ijk_Boring;
+          dres.whatNext    = Dis_StopHere;
+      }
       DIP("cb%s r%u, 0x%x\n", bOP ? "nz" : "z", rN, dst - 1);
       goto decode_success;
    }

--- a/priv/main_main.c
+++ b/priv/main_main.c
@@ -191,16 +191,17 @@ void LibVEX_default_VexControl ( /*OUT*/ VexControl* vcon )
 {
    vex_bzero(vcon, sizeof(*vcon));
    vcon->iropt_verbosity                 = 0;
-   vcon->iropt_level                     = 2;
+   vcon->iropt_level                     = 0;    // No optimization by default
    vcon->iropt_register_updates_default  = VexRegUpdUnwindregsAtMemAccess;
-   vcon->iropt_unroll_thresh             = 120;
-   vcon->guest_max_insns                 = 60;
+   vcon->iropt_unroll_thresh             = 0;
+   vcon->guest_max_insns                 = 1;    // By default, we vex 1 instruction at a time
    vcon->guest_max_bytes                 = 5000;
-   vcon->guest_chase_thresh              = 10;
+   vcon->guest_chase_thresh              = 0;
    vcon->guest_chase_cond                = False;
+   vcon->arm_strict_block_end            = True;
    vcon->arm_allow_optimizing_lookback   = True;
-   vcon->arm64_allow_reordered_writeback = True;
-   vcon->x86_optimize_callpop_idiom      = True;
+   vcon->arm64_allow_reordered_writeback = False;
+   vcon->x86_optimize_callpop_idiom      = False;
 }
 
 
@@ -308,6 +309,14 @@ void LibVEX_Update_Control(const VexControl *vcon)
    vassert(vcon->guest_chase_thresh < vcon->guest_max_insns);
    vassert(vcon->guest_chase_cond == True
            || vcon->guest_chase_cond == False);
+   vassert(vcon->arm_strict_block_end  == True
+           || vcon->arm_strict_block_end  == False);
+   vassert(vcon->arm_allow_optimizing_lookback  == True
+           || vcon->arm_allow_optimizing_lookback  == False);
+   vassert(vcon->arm64_allow_reordered_writeback  == True
+           || vcon->arm64_allow_reordered_writeback  == False);
+   vassert(vcon->x86_optimize_callpop_idiom  == True
+           || vcon->x86_optimize_callpop_idiom  == False);
 
    vex_control            = *vcon;
 }

--- a/pub/libvex.h
+++ b/pub/libvex.h
@@ -496,6 +496,8 @@ typedef
          current instruction pointer in order to check if there are no
          IT instructions so that it can optimize the IR? Default: YES */
       Bool arm_allow_optimizing_lookback;
+      /* Make CB{N}Z arm thumb instruction to be considered as branch */
+      Bool arm_strict_block_end;
       /* Should the arm64 lifter be allowed to re-order register
          writeback in a handful of special cases that make memcheck
          unhappy otherwise? Default: YES */


### PR DESCRIPTION
Added parameter to control branching at CB{N}Z instruction, moved default values definition for VexControl from `pyvex.c:vex_init()`  to priv/main_main.c:LibVEX_default_VexControl