### PR TITLE
fix early initialization of s390_host_hwcaps in LibVEX_FrontEnd

### DIFF
--- a/priv/main_main.c
+++ b/priv/main_main.c
@@ -378,6 +378,11 @@ IRSB *LibVEX_Lift (  VexTranslateArgs *vta,
 
    vex_traceflags = vta->traceflags;
 
+   /* KLUDGE: export hwcaps. */
+   if (vta->arch_host == VexArchS390X) {
+      s390_host_hwcaps = vta->archinfo_host.hwcaps;
+   }
+
    /* First off, check that the guest and host insn sets
       are supported. */
 
@@ -963,8 +968,6 @@ void LibVEX_Codegen (   VexTranslateArgs *vta,
 
       case VexArchS390X:
          mode64       = True;
-         /* KLUDGE: export hwcaps. */
-         s390_host_hwcaps = vta->archinfo_host.hwcaps;
          rRegUniv     = S390FN(getRRegUniverse_S390());
          isMove       = CAST_AS(isMove) S390FN(isMove_S390Instr);
          getRegUsage  


### PR DESCRIPTION
This is upstream commit 95c019.  Helps getting past s390_host_has_ldisp
check in check_hwcaps().