### PR TITLE
Manually select `ar` on macOS so pyvex builds

### DIFF
--- a/Makefile-gcc
+++ b/Makefile-gcc
@@ -20,6 +20,13 @@ CC_NATIVE ?= cc
 AR ?= ar
 RM ?= rm -f
 
+# Don't worry about Windows not having shell, Makefile-msvc will deal
+# with it`
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S), Darwin)
+	AR = /usr/bin/ar 
+endif
+
 STATIC_LIBRARY_FILE = libvex.a
 DYNAMIC_LIBRARY_FILE = libvex.so
 EXTRA_CLEAN_FILES = TAG-* auxprogs/genoffsets


### PR DESCRIPTION
This should allow `pip install pyvex` to work on macOS :) 

Only minor nitpick is, I'm unsure if it's ok to trust that /usr/bin/ar will always be there, or to get the one from `$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar`. It probably doesn't matter.

Should fix #23 