### PR TITLE
ARM: Support decoding semihosting (svc 0x123456).

### DIFF
--- a/priv/guest_arm_toIR.c
+++ b/priv/guest_arm_toIR.c
@@ -17575,7 +17575,8 @@ DisResult disInstr_ARM_WRK (
    /* --------------------- Svc --------------------- */
    if (BITS8(1,1,1,1,0,0,0,0) == (INSN(27,20) & BITS8(1,1,1,1,0,0,0,0))) {
       UInt imm24 = (insn >> 0) & 0xFFFFFF;
-      if (imm24 < 0xffff) {
+      if (imm24 < 0xffff ||
+          imm24 == 0x123456 /* semihosting */) {
          /* A syscall.  We can't do this conditionally, hence: */
          if (condT != IRTemp_INVALID) {
             mk_skip_over_A32_if_cond_is_false( condT );


### PR DESCRIPTION
ARM semihosting uses `svc 0x123456`. See [ARM Information Center](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0471c/Bgbjhiea.html).