### PR TITLE
[WIP] amd64_toIR: Decode endbr.

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -21965,6 +21965,21 @@ Long dis_ESC_0F (
       }
       return delta;
 
+   case 0x1E:  /* ENDBR */
+      if (pfx != (PFX_EMPTY | PFX_F3)) goto decode_failure;
+      switch (getUChar(delta++)) {
+         case 0xFA:
+            DIP("endbr64");
+            break;
+         case 0xFB:
+            DIP("endbr32");
+            break;
+         default:
+            goto decode_failure;
+      }
+
+      return delta;
+
    case 0x1F:
       if (haveF2orF3(pfx)) goto decode_failure;
       modrm = getUChar(delta);
@@ -32388,14 +32403,6 @@ DisResult disInstr_AMD64_WRK (
          /* We don't know what it is. */
          goto decode_failure;
          /*NOTREACHED*/
-      }
-
-      /* endbr: f3 0f 1e fa */
-      if (code[0] == 0xf3 && code[1] == 0x0f
-                          && code[2] == 0x1e
-                          && code[3] == 0xfa) {
-          delta += 4;
-          goto decode_success;
       }
    }
 

--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -32389,6 +32389,14 @@ DisResult disInstr_AMD64_WRK (
          goto decode_failure;
          /*NOTREACHED*/
       }
+
+      /* endbr: f3 0f 1e fa */
+      if (code[0] == 0xf3 && code[1] == 0x0f
+                          && code[2] == 0x1e
+                          && code[3] == 0xfa) {
+          delta += 4;
+          goto decode_success;
+      }
    }
 
    /* Eat prefixes, summarising the result in pfx and sz, and rejecting

--- a/priv/guest_x86_toIR.c
+++ b/priv/guest_x86_toIR.c
@@ -14816,6 +14816,19 @@ DisResult disInstr_X86_WRK (
          case 0xBD: /* REP BSR Gv,Ev */
             delta = dis_bs_E_G ( sorb, sz, delta + 1, False );
             break;
+         case 0x1e: /* ENDBR */
+            delta++;
+            switch (getIByte(delta++)) {
+               case 0xfa:
+                  DIP("endbr64");
+                  break;
+               case 0xfb:
+                  DIP("endbr32");
+                  break;
+               default:
+                  goto decode_failure;
+            }
+            break;
          default:
             goto decode_failure;
          }


### PR DESCRIPTION
TODO:

- [x] Add endbr32 to guest_x86_toIR.c.
- [x] Revert the endbr support implemented using spotter in PyVEX.