### PR TITLE
Feat/amd64 retf

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -8970,11 +8970,11 @@ void dis_retf ( /*MOD*/DisResult* dres, const VexAbiInfo* vbi, ULong d64 )
    IRTemp t1 = newTemp(Ity_I64);
    IRTemp t2 = newTemp(Ity_I64);
    IRTemp t3 = newTemp(Ity_I64);
-   IRTemp t4 = newTemp(Ity_I64);
+   IRTemp t4 = newTemp(Ity_I16);
    assign(t1, getIReg64(R_RSP));
    assign(t2, loadLE(Ity_I64,mkexpr(t1)));
-   assign(t4, loadLE(Ity_I64, binop(Iop_Add64, mkexpr(t1), mkU64(8+d64))));
-   assign(t3, binop(Iop_Add64, mkexpr(t1), mkU64(16+d64)));
+   assign(t4, loadLE(Ity_I16, binop(Iop_Add64, mkexpr(t1), mkU64(8+d64))));
+   assign(t3, binop(Iop_Add64, mkexpr(t1), mkU64(10+d64)));
    putIReg64(R_RSP, mkexpr(t3));
    putSReg(R_CS, mkexpr(t4));
    make_redzone_AbiHint(vbi, t1, t2/*nia*/, "ret");

--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -21249,7 +21249,7 @@ Long dis_ESC_NONE (
       DIP("leave\n");
       return delta;
 
-   case 0xCA: /* RET imm16 */
+   case 0xCA: /* RETF imm16 */
       if (have66orF3(pfx)) goto decode_failure;
       if (haveF2(pfx)) DIP("bnd ; "); /* MPX bnd prefix. */
       d64 = getUDisp16(delta);
@@ -21258,7 +21258,7 @@ Long dis_ESC_NONE (
       DIP("ret $%lld\n", d64);
       return delta;
 
-   case 0xCB: /* RET */
+   case 0xCB: /* RETF */
       if (have66(pfx)) goto decode_failure;
       /* F3 is acceptable on AMD. */
       if (haveF2(pfx)) DIP("bnd ; "); /* MPX bnd prefix. */


### PR DESCRIPTION
This is the simplest possible form of RETF for my current use case. 

The difference between this implementation and the RET implementation is RETF additionally pops R_CS from the stack.

To complete the implementation RETF should check for protected_mode (currently unimplemented in AMD64) and if protected, check the privilege level of the code segment using the selector (Also unimplemented in AMD64). Additional values are popped from the stack if the PL is different from the current one, making this impl invalid for that scenario. 

See this explination of the RETF procedure from [The AMD64 user manual](https://www.amd.com/system/files/TechDocs/24594.pdf)

```
Returns from a procedure previously entered by a CALL Far instruction. This form of the RET
instruction returns to a calling procedure in a different segment than the current code segment. It can
return to the same CPL or to a less privileged CPL.
RET Far pops a target CS and rIP from the stack. If the new code segment is less privileged than the
current code segment, the stack pointer is incremented by the number of bytes indicated by the
immediate operand, if present; then a new SS and rSP are also popped from the stack.
The final value of rSP is incremented by the number of bytes indicated by the immediate operand, if
present. This action skips over the parameters (previously passed to the subroutine) that are no longer
needed.
All stack pops are determined by the operand size. If necessary, the target rIP is zero-extended to 64
bits before assuming program control.
If the CPL changes, the data segment selectors are set to NULL for any of the data segments (DS, ES,
FS, GS) not accessible at the new CPL.
See RET (Near) for information on near returns—returns to procedures located inside the current code
segment. For details about control-flow instructions,
```

Protected mode and segment selectors are implemented in x86 already, they should be at least similar. 