### PR TITLE
support RISC-V 64 in `libvex_basictype.h`

### DIFF
--- a/pub/libvex_basictypes.h
+++ b/pub/libvex_basictypes.h
@@ -213,6 +213,12 @@ typedef  unsigned long HWord;
 #   define VEX_HOST_WORDSIZE 4
 #   define VEX_REGPARM(_n) /* */
 
+#elif defined(__riscv) && defined(__riscv_xlen)
+#   if (__riscv_xlen == 64)
+#       define VEX_HOST_WORDSIZE 8
+#       define VEX_REGPARM(_n) /* */
+#   endif
+
 #elif defined(__tilegx__)
 #   define VEX_HOST_WORDSIZE 8
 #   define VEX_REGPARM(_n) /* */


### PR DESCRIPTION
It seems that the code related to RISC-V 64 has been merged (https://github.com/angr/vex/pull/54), but the corresponding macro definitions are missing in `libvex_basictype.h`.