### PR TITLE
Add auxprogs/genoffsets.dSYM to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 vex
 
 auxprogs/genoffsets
+auxprogs/genoffsets.dSYM
 pub/libvex_guest_offsets.h


### PR DESCRIPTION
This file shows up on macOS during building, can be ignored.