### PR TITLE
codegen_xchg_rAX_Reg: Preserve RAX[63:16] in `xchg AX, r16`

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -8550,17 +8550,17 @@ void codegen_xchg_rAX_Reg ( Prefix pfx, Int sz, UInt regLo3 )
    if (sz == 8) {
       assign( t1, getIReg64(R_RAX) );
       assign( t2, getIRegRexB(8, pfx, regLo3) );
-      putIReg64( R_RAX, mkexpr(t2) );
+      putIRegRAX( 8, mkexpr(t2) );
       putIRegRexB(8, pfx, regLo3, mkexpr(t1) );
    } else if (sz == 4) {
       assign( t1, getIReg32(R_RAX) );
       assign( t2, getIRegRexB(4, pfx, regLo3) );
-      putIReg32( R_RAX, mkexpr(t2) );
+      putIRegRAX( 4, mkexpr(t2) );
       putIRegRexB(4, pfx, regLo3, mkexpr(t1) );
    } else {
       assign( t1, getIReg16(R_RAX) );
       assign( t2, getIRegRexB(2, pfx, regLo3) );
-      putIReg16( R_RAX, mkexpr(t2) );
+      putIRegRAX( 2, mkexpr(t2) );
       putIRegRexB(2, pfx, regLo3, mkexpr(t1) );
    }
    DIP("xchg%c %s, %s\n", 


### PR DESCRIPTION
Fixes angr/angr#3878