### PR TITLE
amd64: Use Intel behavior for 16b sh[lr]d when count>16

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -8163,35 +8163,28 @@ ULong dis_SHLRD_Gv_Ev ( const VexAbiInfo* vbi,
          assign( tmp64,
                  binop(Iop_32HLto64,
                        binop(Iop_16HLto32, mkexpr(esrc), mkexpr(gsrc)),
-                       binop(Iop_16HLto32, mkexpr(gsrc), mkexpr(gsrc))
+                       binop(Iop_16HLto32, mkexpr(esrc), mkexpr(gsrc))
          ));
-         /* result formed by shifting [esrc'gsrc'gsrc'gsrc] */
+         /* result formed by shifting [esrc'gsrc'esrc'gsrc] */
          assign( res64, 
                  binop(Iop_Shr64, 
                        binop(Iop_Shl64, mkexpr(tmp64), mkexpr(tmpSH)),
                        mkU8(48)) );
-         /* subshift formed by shifting [esrc'0000'0000'0000] */
          assign( rss64, 
                  binop(Iop_Shr64, 
-                       binop(Iop_Shl64, 
-                             binop(Iop_Shl64, unop(Iop_16Uto64, mkexpr(esrc)),
-                                              mkU8(48)),
-                             mkexpr(tmpSS)),
+                       binop(Iop_Shl64, mkexpr(tmp64), mkexpr(tmpSS)),
                        mkU8(48)) );
       }
       else
       if (sz == 2 && !left_shift) {
          assign( tmp64,
                  binop(Iop_32HLto64,
-                       binop(Iop_16HLto32, mkexpr(gsrc), mkexpr(gsrc)),
+                       binop(Iop_16HLto32, mkexpr(gsrc), mkexpr(esrc)),
                        binop(Iop_16HLto32, mkexpr(gsrc), mkexpr(esrc))
          ));
-         /* result formed by shifting [gsrc'gsrc'gsrc'esrc] */
+         /* result formed by shifting [gsrc'esrc'gsrc'esrc] */
          assign( res64, binop(Iop_Shr64, mkexpr(tmp64), mkexpr(tmpSH)) );
-         /* subshift formed by shifting [0000'0000'0000'esrc] */
-         assign( rss64, binop(Iop_Shr64, 
-                              unop(Iop_16Uto64, mkexpr(esrc)), 
-                              mkexpr(tmpSS)) );
+         assign( rss64, binop(Iop_Shr64, mkexpr(tmp64), mkexpr(tmpSS)) );
       }
 
    } else {


### PR DESCRIPTION
According to the Intel SDM for `shld` and `shrd` instructions, the result is undefined when shift count is greater than operand size. Observed behavior of Intel CPUs in this case is to shift bits in from source first, then from destination.  This is also how QEMU models these instructions.  Discovered via QEMU differential tests.

Submitted upstream at https://bugs.kde.org/show_bug.cgi?id=492961