### PR TITLE
amd64: Remap `int imm8` Ijk_{NoDecode,Sys_int*}->Ijk_Sys_syscall

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -21318,15 +21318,10 @@ Long dis_ESC_NONE (
 
    case 0xCD: /* INT imm8 */
       d64 = getUChar(delta); delta++;
-
-      /* Handle int $0xD2 (Solaris fasttrap syscalls). */
-      if (d64 == 0xD2) {
-         jmp_lit(dres, Ijk_Sys_int210, guest_RIP_bbstart + delta);
-         vassert(dres->whatNext == Dis_StopHere);
-         DIP("int $0xD2\n");
-         return delta;
-      }
-      goto decode_failure;
+      jmp_lit(dres, Ijk_Sys_syscall, guest_RIP_bbstart + delta);
+      vassert(dres->whatNext == Dis_StopHere);
+      DIP("int $0x%x\n", d64);
+      return delta;
 
    case 0xD0: { /* Grp2 1,Eb */
       Bool decode_OK = True;


### PR DESCRIPTION
Instead of handling vectors with unique jumpkinds or NoDecode, simply exit with a Ijk_Sys_syscall for higher level handling.