### PR TITLE
amd64: Remap `int imm8` Ijk_Sys_syscall -> Ijk_Sys_int

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -21318,7 +21318,7 @@ Long dis_ESC_NONE (
 
    case 0xCD: /* INT imm8 */
       d64 = getUChar(delta); delta++;
-      jmp_lit(dres, Ijk_Sys_syscall, guest_RIP_bbstart + delta);
+      jmp_lit(dres, Ijk_Sys_int, guest_RIP_bbstart + delta);
       vassert(dres->whatNext == Dis_StopHere);
       DIP("int $0x%x\n", d64);
       return delta;

--- a/pub/libvex_ir.h
+++ b/pub/libvex_ir.h
@@ -2350,6 +2350,7 @@ typedef
       /* Unfortunately, various guest-dependent syscall kinds.  They
 	 all mean: do a syscall before continuing. */
       Ijk_Sys_syscall,    /* amd64/x86 'syscall', ppc 'sc', arm 'svc #0' */
+      Ijk_Sys_int,        /* amd64/x86 'int *' */
       Ijk_Sys_int32,      /* amd64/x86 'int $0x20' */
       Ijk_Sys_int128,     /* amd64/x86 'int $0x80' */
       Ijk_Sys_int129,     /* amd64/x86 'int $0x81' */


### PR DESCRIPTION
Avoid breaking code that expects `Ijk_Sys_syscall` is actually an x86-64 `syscall` op. Instead of generating Ijk_Sys_syscall jumpkind for `int imm8`, use new jumpkind `Ijk_Sys_int` for generic software interrupt.