### PR TITLE
fix typo in genoffsets.c

### DIFF
--- a/auxprogs/genoffsets.c
+++ b/auxprogs/genoffsets.c
@@ -1019,7 +1019,7 @@ int main(int argc, char **argv)
    GENOFFSET(RISCV64,riscv64,f5);
    GENOFFSET(RISCV64,riscv64,f6);
    GENOFFSET(RISCV64,riscv64,f7);
-   GENOFFSET(RISCV64,riscv64,f9);
+   GENOFFSET(RISCV64,riscv64,f8);
    GENOFFSET(RISCV64,riscv64,f9);
    GENOFFSET(RISCV64,riscv64,f10);
    GENOFFSET(RISCV64,riscv64,f11);


### PR DESCRIPTION
Removed duplicate declaration of register f9
Added missing declaration of register f8