### PR TITLE
Support wasm32 hosts in VEX basic types

### DIFF
--- a/pub/libvex_basictypes.h
+++ b/pub/libvex_basictypes.h
@@ -181,6 +181,10 @@ typedef  unsigned long HWord;
 #   define VEX_HOST_WORDSIZE 4
 #   define VEX_REGPARM(_n) __attribute__((regparm(_n)))
 
+#elif defined(__wasm32__)
+#   define VEX_HOST_WORDSIZE 4
+#   define VEX_REGPARM(_n) /* */
+
 #elif defined(_WIN32) && !defined(_WIN64)
 #   define VEX_HOST_WORDSIZE 4
 #   define VEX_REGPARM(_n) /* ought to be __fastcall */


### PR DESCRIPTION
## Summary

- recognize wasm32 as a 32-bit VEX host
- disable the native register-parameter attribute on WebAssembly
- provide the host definitions needed when VEX is compiled into PyVEX under Emscripten

## Validation

Consumed successfully by the PyVEX Pyodide build. The resulting runtime lifted AMD64 and ARM instructions and preserved a 64-bit guest data reference on the wasm32 host.