### PR TITLE
s390x: handle POPCNT total-count mode

### DIFF
--- a/priv/guest_s390_toIR.c
+++ b/priv/guest_s390_toIR.c
@@ -14932,7 +14932,7 @@ s390_irgen_FLOGR(UChar r1, UChar r2)
 }
 
 static const HChar *
-s390_irgen_POPCNT(UChar r1, UChar r2)
+s390_irgen_POPCNT(UChar m3, UChar r1, UChar r2)
 {
    Int i;
    IRTemp val = newTemp(Ity_I64);
@@ -14956,6 +14956,17 @@ s390_irgen_POPCNT(UChar r1, UChar r2)
                    binop(Iop_And64,
                          binop(Iop_Shr64, mkexpr(val), mkU8(1 << i)),
                          mkexpr(mask[i]))));
+      val = tmp;
+   }
+   if (m3 & 8) {
+      IRTemp tmp = newTemp(Ity_I64);
+
+      /* Horizontally sum the eight per-byte population counts. */
+      assign(tmp,
+             binop(Iop_Shr64,
+                   binop(Iop_Mul64, mkexpr(val),
+                         mkU64(0x0101010101010101ULL)),
+                   mkU8(56)));
       val = tmp;
    }
    s390_cc_thunk_putZ(S390_CC_OP_BITWISE, val);
@@ -19835,8 +19846,8 @@ s390_decode_4byte_and_irgen(const UChar *bytes)
    case 0xb9e0: s390_format_RRF_U0RR(s390_irgen_LOCFHR, RRF3_r3(ovl),
                                      RRF3_r1(ovl), RRF3_r2(ovl),
                                      S390_XMNM_LOCFHR);  goto ok;
-   case 0xb9e1: s390_format_RRE_RR(s390_irgen_POPCNT, RRE_r1(ovl),
-                                   RRE_r2(ovl));  goto ok;
+   case 0xb9e1: s390_format_RRF_M0RERE(s390_irgen_POPCNT, RRF2_m3(ovl),
+                                       RRF2_r1(ovl), RRF2_r2(ovl));  goto ok;
    case 0xb9e2: s390_format_RRF_U0RR(s390_irgen_LOCGR, RRF3_r3(ovl),
                                      RRF3_r1(ovl), RRF3_r2(ovl),
                                      S390_XMNM_LOCGR);  goto ok;


### PR DESCRIPTION
## Summary

s390x `POPCNT` (`0xB9E1`) is an RRF-c instruction. VEX currently decodes it as RRE, discarding the M3 field, and always returns per-byte population counts. This makes the M3=8 total-count form return an incorrect result.

For example, with source `0xffffffffffffffff`:

- `b9e100cc` (M3=0): `0x0808080808080808`
- `b9e180cc` (M3=8): should return `64`, but currently also returns `0x0808080808080808`

IBM z/Architecture Principles of Operation SA22-7832-14, page 7-424 defines M3 bit 0 (encoded as numeric M3=8) as counting all set bits into a scalar result.

## Fix

- Decode `POPCNT` with the existing RRF-c-compatible formatter and extract M3.
- Preserve the current per-byte reduction for M3=0.
- Horizontally sum the eight byte counts when `(m3 & 8)` is set.
- Keep the existing zero/nonzero CC thunk; zero is equivalent in both result forms.

## Reproduction

```python
import angr, archinfo, claripy
A = archinfo.ArchS390X()
def popcnt(code_hex, val):
    st = angr.load_shellcode(bytes.fromhex(code_hex), A).factory.blank_state(addr=0)
    st.regs.r12 = claripy.BVV(val, 64)
    s = st.step(num_inst=1).successors[0]
    return s.solver.eval(s.regs.r12) & ((1 << 64) - 1)

# b9e1 80cc = popcnt %r12,%r12,8   (M3=8, total count)
print(hex(popcnt('b9e180cc', (1<<64)-1)))   # angr 0x0808080808080808 ; want 0x40 (64)
# b9e1 00cc = popcnt %r12,%r12,0   (M3=0, per-byte) -- correct
print(hex(popcnt('b9e100cc', (1<<64)-1)))   # 0x0808080808080808 (correct)
```