### PR TITLE
arm: check SMLAD overflow on final result

### DIFF
--- a/priv/guest_arm_toIR.c
+++ b/priv/guest_arm_toIR.c
@@ -10644,17 +10644,31 @@ static Bool decode_V6MEDIA_instruction (
            putIRegA( regD, ire_result, condT, Ijk_Boring );
 
         if (isAD) {
+           IRTemp irt_wide = newTemp(Ity_I64);
+
+           assign(
+              irt_wide,
+              binop(
+                 Iop_Add64,
+                 binop(Iop_Add64,
+                       unop(Iop_32Sto64, mkexpr(irt_prod_lo)),
+                       unop(Iop_32Sto64, mkexpr(irt_prod_hi))),
+                 unop(Iop_32Sto64, mkexpr(irt_regA))
+              )
+           );
            or_into_QFLAG32(
-              signed_overflow_after_Add32( mkexpr(irt_sum),
-                                           irt_prod_lo, irt_prod_hi ),
+              unop(Iop_1Uto32,
+                   binop(Iop_CmpNE64,
+                         mkexpr(irt_wide),
+                         unop(Iop_32Sto64, ire_result))),
+              condT
+           );
+        } else {
+           or_into_QFLAG32(
+              signed_overflow_after_Add32( ire_result, irt_sum, irt_regA ),
               condT
            );
         }
-
-        or_into_QFLAG32(
-           signed_overflow_after_Add32( ire_result, irt_sum, irt_regA ),
-           condT
-        );
 
         DIP("sml%cd%s%s r%u, r%u, r%u, r%u\n",
             isAD ? 'a' : 's',


### PR DESCRIPTION
## Summary

ARM `SMLAD` and `SMLADX` set the sticky Q flag when the complete signed sum of both halfword products and `Ra` does not fit in 32 bits. The current lifter checks overflow once after adding the products and again after adding `Ra`. This incorrectly sets Q when `Ra` cancels an intermediate overflow.
```
  full_result = signed_product_low + signed_product_high + signed(Ra)
  Rd = low32(full_result)
  if full_result != sign_extend_32(Rd):
  Therefore, overflow is tested once on the complete mathematical result.
VEX instead:
  1. Sets sticky Q if that intermediate value overflows.
  2. Adds Ra and checks overflow again.
```
## Reproducer

With angr/pyvex 9.3.0:

```python
import angr

for name, code in [("smlad", bytes.fromhex("113200e7")),
                   ("smladx", bytes.fromhex("313200e7"))]:
    project = angr.load_shellcode(code, arch="ARMEL", load_address=0x1000)
    state = project.factory.blank_state(addr=0x1000)
    state.regs.r1 = 0x80008000
    state.regs.r2 = 0x80008000
    state.regs.r3 = 0xffffffff
    state.regs.qflag32 = 0
    out = project.factory.successors(state, num_inst=1).flat_successors[0]
    print(name, hex(out.solver.eval(out.regs.r0)),
          out.solver.eval(out.regs.qflag32) & 1)
```

Current output:

```text
smlad  0x7fffffff 1
smladx 0x7fffffff 1
```

Expected output:

```text
smlad  0x7fffffff 0
smladx 0x7fffffff 0
```

Each signed halfword product is `0x40000000`. Their intermediate sum is `0x80000000`, but adding `Ra = -1` produces the representable final result `0x7fffffff`. ARM defines the overflow test over this complete three-term result.

## Fix

Compute the complete signed sum in I64 and compare it with the sign extension of its low 32-bit result. Q is ORed only with that final representability check. The SMLSD/SMLSDX path retains its existing final addition check.


