### PR TITLE
x86: preserve ZF across BT-family instructions

### DIFF
--- a/priv/guest_amd64_toIR.c
+++ b/priv/guest_amd64_toIR.c
@@ -4134,19 +4134,24 @@ ULong dis_Grp8_Imm ( const VexAbiInfo* vbi,
       }
    }
 
-   /* Copy relevant bit from t2 into the carry flag. */
-   /* Flags: C=selected bit, O,S,Z,A,P undefined, so are set to zero. */
-   stmt( IRStmt_Put( OFFB_CC_OP,   mkU64(AMD64G_CC_OP_COPY) ));
-   stmt( IRStmt_Put( OFFB_CC_DEP2, mkU64(0) ));
-   stmt( IRStmt_Put( 
-            OFFB_CC_DEP1,
-            binop(Iop_And64,
-                  binop(Iop_Shr64, mkexpr(t2), mkU8(src_val)),
-                  mkU64(1))
-       ));
-   /* Set NDEP even though it isn't used.  This makes redundant-PUT
-      elimination of previous stores to this field work better. */
-   stmt( IRStmt_Put( OFFB_CC_NDEP, mkU64(0) ));
+   /* Preserve the defined ZF and replace CF with the selected bit. */
+   IRTemp oldflags = newTemp(Ity_I64);
+   assign(oldflags, mk_amd64g_calculate_rflags_all());
+
+   IRTemp new_cf = newTemp(Ity_I64);
+   assign(new_cf,
+          binop(Iop_And64,
+                binop(Iop_Shr64, mkexpr(t2), mkU8(src_val)),
+                mkU64(1)));
+
+   stmt(IRStmt_Put(OFFB_CC_OP, mkU64(AMD64G_CC_OP_COPY)));
+   stmt(IRStmt_Put(OFFB_CC_DEP1,
+                   binop(Iop_Or64,
+                         binop(Iop_And64, mkexpr(oldflags),
+                               mkU64(~AMD64G_CC_MASK_C)),
+                         mkexpr(new_cf))));
+   stmt(IRStmt_Put(OFFB_CC_DEP2, mkU64(0)));
+   stmt(IRStmt_Put(OFFB_CC_NDEP, mkU64(0)));
 
    return delta;
 }
@@ -8380,7 +8385,7 @@ ULong dis_bt_G_E ( const VexAbiInfo* vbi,
    /* Side effect done; now get selected bit into Carry flag */
    /* Flags: C=selected bit, Z=unaffected, O,S,A,P undefined */
    IRTemp old_cc = newTemp(Ity_I64);
-   assign(old_cc, IRExpr_Get(OFFB_CC_DEP1, Ity_I64));
+   assign(old_cc, mk_amd64g_calculate_rflags_all());
 
    IRTemp new_cf = newTemp(Ity_I64);
    assign(new_cf, binop(Iop_And64,
@@ -8388,7 +8393,7 @@ ULong dis_bt_G_E ( const VexAbiInfo* vbi,
                               mkexpr(t_bitno2)),
                         mkU64(1)));
 
-   /* Replace CF but reserve the old flags (for ZF) */
+   /* Replace CF but preserve the old flags (for ZF) */
    IRTemp merged = newTemp(Ity_I64);
    assign(merged,
           binop(Iop_Or64,
@@ -8398,6 +8403,7 @@ ULong dis_bt_G_E ( const VexAbiInfo* vbi,
    stmt(IRStmt_Put(OFFB_CC_OP, mkU64(AMD64G_CC_OP_COPY)));
    stmt(IRStmt_Put(OFFB_CC_DEP1, mkexpr(merged)));
    stmt(IRStmt_Put(OFFB_CC_DEP2, mkU64(0)));
+   stmt(IRStmt_Put(OFFB_CC_NDEP, mkU64(0)));
 
    /* Move reg operand from stack back to reg */
    if (epartIsReg(modrm)) {

--- a/priv/guest_x86_toIR.c
+++ b/priv/guest_x86_toIR.c
@@ -2883,19 +2883,24 @@ UInt dis_Grp8_Imm ( UChar sorb,
       }
    }
 
-   /* Copy relevant bit from t2 into the carry flag. */
-   /* Flags: C=selected bit, O,S,Z,A,P undefined, so are set to zero. */
-   stmt( IRStmt_Put( OFFB_CC_OP,   mkU32(X86G_CC_OP_COPY) ));
-   stmt( IRStmt_Put( OFFB_CC_DEP2, mkU32(0) ));
-   stmt( IRStmt_Put( 
-            OFFB_CC_DEP1,
-            binop(Iop_And32,
-                  binop(Iop_Shr32, mkexpr(t2), mkU8(src_val)),
-                  mkU32(1))
-       ));
-   /* Set NDEP even though it isn't used.  This makes redundant-PUT
-      elimination of previous stores to this field work better. */
-   stmt( IRStmt_Put( OFFB_CC_NDEP, mkU32(0) ));
+   /* Preserve the defined ZF and replace CF with the selected bit. */
+   IRTemp oldflags = newTemp(Ity_I32);
+   assign(oldflags, mk_x86g_calculate_eflags_all());
+
+   IRTemp new_cf = newTemp(Ity_I32);
+   assign(new_cf,
+          binop(Iop_And32,
+                binop(Iop_Shr32, mkexpr(t2), mkU8(src_val)),
+                mkU32(1)));
+
+   stmt(IRStmt_Put(OFFB_CC_OP, mkU32(X86G_CC_OP_COPY)));
+   stmt(IRStmt_Put(OFFB_CC_DEP1,
+                   binop(Iop_Or32,
+                         binop(Iop_And32, mkexpr(oldflags),
+                               mkU32(~X86G_CC_MASK_C)),
+                         mkexpr(new_cf))));
+   stmt(IRStmt_Put(OFFB_CC_DEP2, mkU32(0)));
+   stmt(IRStmt_Put(OFFB_CC_NDEP, mkU32(0)));
 
    return delta;
 }
@@ -6863,21 +6868,25 @@ UInt dis_bt_G_E ( const VexAbiInfo* vbi,
       }
    }
  
-   /* Side effect done; now get selected bit into Carry flag */
-   /* Flags: C=selected bit, O,S,Z,A,P undefined, so are set to zero. */
-   stmt( IRStmt_Put( OFFB_CC_OP,   mkU32(X86G_CC_OP_COPY) ));
-   stmt( IRStmt_Put( OFFB_CC_DEP2, mkU32(0) ));
-   stmt( IRStmt_Put( 
-            OFFB_CC_DEP1,
-            binop(Iop_And32,
-                  binop(Iop_Shr32, 
-                        unop(Iop_8Uto32, mkexpr(t_fetched)),
-                        mkexpr(t_bitno2)),
-                  mkU32(1)))
-       );
-   /* Set NDEP even though it isn't used.  This makes redundant-PUT
-      elimination of previous stores to this field work better. */
-   stmt( IRStmt_Put( OFFB_CC_NDEP, mkU32(0) ));
+   /* Preserve the defined ZF and replace CF with the selected bit. */
+   IRTemp oldflags = newTemp(Ity_I32);
+   assign(oldflags, mk_x86g_calculate_eflags_all());
+
+   IRTemp new_cf = newTemp(Ity_I32);
+   assign(new_cf,
+          binop(Iop_And32,
+                binop(Iop_Shr32, unop(Iop_8Uto32, mkexpr(t_fetched)),
+                      mkexpr(t_bitno2)),
+                mkU32(1)));
+
+   stmt(IRStmt_Put(OFFB_CC_OP, mkU32(X86G_CC_OP_COPY)));
+   stmt(IRStmt_Put(OFFB_CC_DEP1,
+                   binop(Iop_Or32,
+                         binop(Iop_And32, mkexpr(oldflags),
+                               mkU32(~X86G_CC_MASK_C)),
+                         mkexpr(new_cf))));
+   stmt(IRStmt_Put(OFFB_CC_DEP2, mkU32(0)));
+   stmt(IRStmt_Put(OFFB_CC_NDEP, mkU32(0)));
 
    /* Move reg operand from stack back to reg */
    if (epartIsReg(modrm)) {


### PR DESCRIPTION
## Summary

This completes the ZF-preservation fix started by #79 for `BT`, `BTS`, `BTR`, and `BTC`. Intel defines CF as the selected bit and ZF as unaffected for all four instructions.

PR #79 changed only the amd64 register-index decoder. Three other decoder paths still replace the flag state with CF alone, and the changed path reads raw `CC_DEP1`, which is not packed RFLAGS when the preceding flags are lazy.

This is also a follow-up to the remaining BTC portion of angr/angr#6067. That grouped issue is closed because its separate MUL fix used `Fixes #6067`; the closure does not cover these remaining VEX paths.

## Missing cases after #79

| Architecture | Bit-index encoding | Current behavior |
|---|---|---|
| amd64 | register (`0F A3/AB/B3/BB`) | #79 preserves ZF only if flags are already materialized; a lazy predecessor such as `cmp` is mishandled |
| amd64 | immediate (`0F BA /4-/7`) | replaces the flag state with CF alone |
| x86 | register (`0F A3/AB/B3/BB`) | replaces the flag state with CF alone |
| x86 | immediate (`0F BA /4-/7`) | replaces the flag state with CF alone |

Each decoder handles both register and memory destinations, and the issue applies to BT/BTS/BTR/BTC because they share the same flag-writing code.

## Root cause

VEX represents arithmetic flags lazily. After `cmp`, the state is conceptually:

```text
CC_OP   = SUB
CC_DEP1 = left operand
CC_DEP2 = right operand
```

PR #79 reads `CC_DEP1` directly and treats it as packed RFLAGS before switching `CC_OP` to COPY. Operand bit 6 is therefore copied as ZF. The untouched paths instead switch to COPY with `CC_DEP1` containing only the new CF, which always clears ZF.

The fix materializes the previous flags with `mk_amd64g_calculate_rflags_all()` or `mk_x86g_calculate_eflags_all()`, replaces only CF with the selected bit, and stores the result in COPY form.

## Reproducer

With pyvex built from current VEX master:

```python
import angr

cases = [
    ("amd64-reg", "amd64", "450fbbcd", {"r13": 0xdeadbeef, "r9": 0x12345678}),
    ("amd64-imm", "amd64", "410fbafd05", {"r13": 0xdeadbeef}),
    ("x86-reg", "x86", "0fbbca", {"edx": 0xdeadbeef, "ecx": 0x12345678}),
    ("x86-imm", "x86", "0fbafa05", {"edx": 0xdeadbeef}),
]

for name, arch, encoding, registers in cases:
    # cmp eax, 1 sets ZF=1 lazily when EAX is 1.
    project = angr.load_shellcode(
        bytes.fromhex("83f801" + encoding), arch, load_address=0x1000
    )
    state = project.factory.blank_state(addr=0x1000)
    state.regs.eax = 1
    for register, value in registers.items():
        setattr(state.regs, register, value)
    out = project.factory.successors(state, num_inst=2).flat_successors[0]
    flags = out.solver.eval(out.regs.eflags)
    print(name, "ZF=", (flags >> 6) & 1)
```

Current master:

```text
amd64-reg ZF= 0
amd64-imm ZF= 0
x86-reg ZF= 0
x86-imm ZF= 0
```

This branch:

```text
amd64-reg ZF= 1
amd64-imm ZF= 1
x86-reg ZF= 1
x86-imm ZF= 1
```

## Validation

Built pyvex 9.3.0 with this exact VEX branch and checked the cross-product of:

- x86 and amd64;
- register and immediate bit indices;
- BT, BTS, BTR, and BTC;
- register and memory destinations;
- prior lazy ZF values 0 and 1.

Current master passes 32/64 and fails every prior-ZF=1 case. This branch passes all 64/64 cases with the destination value, CF, and ZF matching the reference.

Intel reference: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html (Volume 2A, BT/BTC/BTR/BTS `Flags Affected`).