### PR TITLE
s390x: keep the EXRL prefetch inside the code buffer

### DIFF
--- a/priv/guest_s390_toIR.c
+++ b/priv/guest_s390_toIR.c
@@ -58,6 +58,10 @@ static const HChar *s390_irgen_BIC(UChar r1, IRTemp op2addr);
 /* The IRSB* into which we're generating code. */
 static IRSB *irsb;
 
+/* Pointer to the guest code area (points to start of BB, not to the
+   insn being processed). */
+static const UChar *guest_code;
+
 /* The guest address for the instruction currently being
    translated. */
 static Addr64 guest_IA_curr_instr;
@@ -13060,13 +13064,32 @@ static const HChar *
 s390_irgen_EXRL(UChar r1, UInt offset)
 {
    IRTemp addr = newTemp(Ity_I64);
-   Addr64 bytes_addr = guest_IA_curr_instr + offset * 2UL;
-   UChar *bytes = exrl_bytes + offset * 2UL;
+   Long   displacement = (Long)(Int)offset * 2;
+   Addr64 bytes_addr = guest_IA_curr_instr + (ULong)displacement;
+
    /* we might save one round trip because we know the target */
-   if (!last_execute_target)
-      last_execute_target = ((ULong)bytes[0] << 56) | ((ULong)bytes[1] << 48) |
-                            ((ULong)bytes[2] << 40) | ((ULong)bytes[3] << 32) |
-                            ((ULong)bytes[4] << 24) | ((ULong)bytes[5] << 16);
+   if (!last_execute_target) {
+      /* The target comes out of the code buffer rather than out of guest
+         memory, so it is only available while it lies inside that buffer.
+         Nothing constrains the displacement, so it often does not. Leaving
+         last_execute_target at zero makes s390_irgen_EX emit the generic
+         code that looks the target up when the block runs. */
+      Long target_off = (exrl_bytes - guest_code) + displacement;
+      Long buffer_size = vex_control.guest_bytes_size > 0
+                            ? (Long)vex_control.guest_bytes_size
+                            : (Long)vex_control.guest_max_bytes;
+
+      if (target_off >= 0 && target_off + 6 <= buffer_size) {
+         const UChar *bytes = guest_code + target_off;
+
+         last_execute_target = ((ULong)bytes[0] << 56) |
+                               ((ULong)bytes[1] << 48) |
+                               ((ULong)bytes[2] << 40) |
+                               ((ULong)bytes[3] << 32) |
+                               ((ULong)bytes[4] << 24) |
+                               ((ULong)bytes[5] << 16);
+      }
+   }
    assign(addr, mkU64(bytes_addr));
    s390_irgen_EX(r1, addr);
    return "exrl";
@@ -22018,7 +22041,7 @@ disInstr_S390(IRSB        *irsb_IN,
               Bool       (*resteerOkFn)(void *, Addr),
               Bool         resteerCisOk,
               void        *callback_opaque,
-              const UChar *guest_code,
+              const UChar *guest_code_IN,
               Long         delta,
               Addr         guest_IP,
               VexArch      guest_arch,
@@ -22030,6 +22053,7 @@ disInstr_S390(IRSB        *irsb_IN,
    vassert(guest_arch == VexArchS390X);
 
    /* Set globals (see top of this file) */
+   guest_code = guest_code_IN;
    guest_IA_curr_instr = guest_IP;
    irsb = irsb_IN;
    resteer_fn = resteerOkFn;

--- a/priv/main_main.c
+++ b/priv/main_main.c
@@ -207,6 +207,7 @@ void LibVEX_default_VexControl ( /*OUT*/ VexControl* vcon )
    vcon->iropt_unroll_thresh             = 120;
    vcon->guest_max_insns                 = 60;
    vcon->guest_max_bytes                 = 5000;
+   vcon->guest_bytes_size                = 0;
    vcon->guest_chase_thresh              = 10;
    vcon->guest_chase_cond                = False;
    vcon->regalloc_version               = 3;
@@ -319,6 +320,7 @@ void LibVEX_Update_Control(const VexControl *vcon)
    vassert(vcon->iropt_unroll_thresh <= 400);
    vassert(vcon->guest_max_insns >= 1);
    vassert(vcon->guest_max_insns <= 100);
+   vassert(vcon->guest_bytes_size >= 0);
    vassert(vcon->guest_chase_thresh >= 0);
    vassert(vcon->guest_chase_thresh < vcon->guest_max_insns);
    vassert(vcon->guest_chase_cond == True

--- a/pub/libvex.h
+++ b/pub/libvex.h
@@ -498,6 +498,12 @@ typedef
       Int guest_max_insns;
       /* What's the maximum basic block size in bytes? Default=5000 */
       Int guest_max_bytes;
+      /* How many bytes may be read from VexTranslateArgs::guest_bytes? A
+         front end that looks outside the block it is translating -- the
+         s390x EXRL target is read out of the buffer -- must stay inside
+         that. Zero means the client did not say, in which case no more than
+         guest_max_bytes may be read. Default=0 */
+      Int guest_bytes_size;
       /* How aggressive should front ends be in following
          unconditional branches to known destinations?  Default=10,
          meaning that if a block contains less than 10 guest insns so


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`s390_irgen_EXRL` reads its target straight out of the buffer being translated, at `exrl_bytes + offset * 2`, with nothing bounding the result — and it reads the displacement as unsigned, unlike every other RIL-b handler. A bogus or truncated EXRL therefore reads far outside the buffer: lifting the seven bytes `a75bffff c650ff` as s390x is enough to segfault the process.

Record the buffer base in `disInstr_S390`, sign-extend the displacement, and prefetch only when the whole six-byte target lies inside the buffer. Otherwise `s390_irgen_EX` emits the run-time lookup it already emits for an unknown target. `VexControl` gains `guest_bytes_size` so a client whose buffer is larger than the block being translated can say how much of it may be read.

Consumed by angr/pyvex#564, which carries the regression tests. Validation: https://github.com/angr/vex/pull/89#issuecomment-5257399264
