### PR TITLE
riscv64: Restore the IR types 7576d04 widened

### DIFF
--- a/priv/guest_riscv64_toIR.c
+++ b/priv/guest_riscv64_toIR.c
@@ -2015,7 +2015,7 @@ static Bool dis_RV64A(/*MB_OUT*/ DisResult* dres,
          if (rd != 0)
             putIReg64(irsb, rd, mkU64(0));
       } else {
-         IRTemp res = newTemp(irsb, Ity_I64);
+         IRTemp res = newTemp(irsb, Ity_I1);
          stmt(irsb, IRStmt_LLSC(Iend_LE, res, getIReg64(rs1),
                                 narrowFrom64(ty, getIReg64(rs2))));
          /* IR semantics: res is 1 if store succeeds, 0 if it fails. Need to set
@@ -2023,7 +2023,7 @@ static Bool dis_RV64A(/*MB_OUT*/ DisResult* dres,
          if (rd != 0)
             putIReg64(
                irsb, rd,
-               binop(Iop_Xor64, unop(Iop_32Uto64, mkexpr(res)), mkU64(1)));
+               binop(Iop_Xor64, unop(Iop_1Uto64, mkexpr(res)), mkU64(1)));
       }
 
       if (aqrl & 0x2)
@@ -2487,11 +2487,13 @@ static Bool dis_RV64F(/*MB_OUT*/ DisResult* dres,
             switch (rm) {
             case 0b010:
                assign(irsb, res,
-                      binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_EQ)));
+                      unop(Iop_1Uto32,
+                           binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_EQ))));
                break;
             case 0b001:
                assign(irsb, res,
-                      binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_LT)));
+                      unop(Iop_1Uto32,
+                           binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_LT))));
                break;
             case 0b000:
                assign(irsb, res,
@@ -2984,11 +2986,13 @@ static Bool dis_RV64D(/*MB_OUT*/ DisResult* dres,
             switch (rm) {
             case 0b010:
                assign(irsb, res,
-                      binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_EQ)));
+                      unop(Iop_1Uto32,
+                           binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_EQ))));
                break;
             case 0b001:
                assign(irsb, res,
-                      binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_LT)));
+                      unop(Iop_1Uto32,
+                           binop(Iop_CmpEQ32, mkexpr(cmp), mkU32(Ircr_LT))));
                break;
             case 0b000:
                assign(irsb, res,


### PR DESCRIPTION
THIS MESSAGE WAS GENERATED BY AN AUTOMATED PROCESS

`7576d04` ("riscv: fix instructions that use the unsupported Ity_1 data type") widened three
`Ity_I1` temporaries to `Ity_I64`/`Ity_I32` without adapting what is assigned to them, so six
instruction forms now fail the IR sanity check and libVEX reports the whole block as
`Ijk_NoDecode`:

* `sc.w` / `sc.d`. `IRStmt_LLSC`'s result type is fixed by the IR contract:
  `pub/libvex_ir.h` says "STOREDATA != NULL (SC): transfer type = type of STOREDATA, and
  RESULT :: Ity_I1". Widening the temp makes the statement itself invalid, and no other
  encoding of a store-conditional exists. `guest_arm64_toIR.c` builds the same sequence with
  `Ity_I1` and `Iop_1Uto64`, which is what this restores.
* `feq.s` / `flt.s` / `feq.d` / `flt.d`. Their `Iop_CmpEQ32` yields `Ity_I1` into an `Ity_I32`
  temp. The `fle` case in the same `switch` already wraps its comparisons in `Iop_1Uto32`; feq
  and flt now do the same.

Before, on `master`:

```
sc.d a3, a1, (s2)   af36b918   size=0 jumpkind=Ijk_NoDecode
sc.w a3, a1, (s2)   af26b918   size=0 jumpkind=Ijk_NoDecode
feq.s a0, fa0, fa1  5325b5a0   size=0 jumpkind=Ijk_NoDecode
flt.s a0, fa0, fa1  5315b5a0   size=0 jumpkind=Ijk_NoDecode
feq.d a0, fa0, fa1  5325b5a2   size=0 jumpkind=Ijk_NoDecode
flt.d a0, fa0, fa1  5315b5a2   size=0 jumpkind=Ijk_NoDecode
fle.s a0, fa0, fa1  5305b5a0   size=4 jumpkind=Ijk_Boring
```

with `vex: the 'impossible' happened: sanityCheckFail: exiting due to bad IR` and
`ERROR = Ist.LLSC(SC).result: not :: Ity_I1` on stderr. After, all six decode.

The visible cost is in angr: a RISC-V block that runs into one of these becomes undecodable
bytes, and `CFGFast`'s linear scan then restarts two bytes into the four-byte instruction, so
blocks begin in the middle of instructions. Over a corpus sweep this accounted for the whole
RISC-V share of that symptom.

Consumed by angr/pyvex#566, which carries the regression tests. Fixes angr/pyvex#516,
whose diagnosis covers `flt` only.

Validation: https://github.com/angr/pyvex/pull/566#issuecomment-5287246143